### PR TITLE
Fixed parsing error in QnaServiceProvider.

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/QnaServiceProvider.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/QnaServiceProvider.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
             {
                 IsTest = isTestKnowledgeBase,
                 Question = question?.Trim(),
-                ScoreThreshold = Convert.ToDouble(this.options.ScoreThreshold),
+                ScoreThreshold = Convert.ToDouble(this.options.ScoreThreshold, CultureInfo.InvariantCulture),
             };
 
             if (previousQnAId != null && previousUserQuery != null)


### PR DESCRIPTION
Changed to the culture-independent way in case of getting ScoreThreshold config value.