### PR TITLE
Fix for message size is too large error

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                                     DisplayText = item.DisplayText,
                                     Text = item.DisplayText,
                                 },
-                                PreviousQuestions = new List<QnADTO> { previousQuestions.Last() },
+                                PreviousQuestions = new List<QnADTO> { previousQuestions.LastOrDefault() },
                                 IsPrompt = true,
                             },
                         },

--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                                     DisplayText = item.DisplayText,
                                     Text = item.DisplayText,
                                 },
-                                PreviousQuestions = previousQuestions,
+                                PreviousQuestions = new List<QnADTO> { previousQuestions.Last() },
                                 IsPrompt = true,
                             },
                         },


### PR DESCRIPTION
For multi-level multi-turn QnA KB, storing all previous questions in an AC payload for every prompt will cause the message size is rapidly exceeded MSTeams message size limit. Because in the original code all previous questions are never used storing just the last previous question into an AC payload will fix that issue and won't cause breaking changes. 

Fix #121 
Fix #112 