### PR TITLE
Fix for a message size is too large error

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus/Cards/ResponseCard.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using AdaptiveCards;
     using Microsoft.Azure.CognitiveServices.Knowledge.QnAMaker.Models;
     using Microsoft.Bot.Schema;
@@ -202,7 +203,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Cards
                                     DisplayText = item.DisplayText,
                                     Text = item.DisplayText,
                                 },
-                                PreviousQuestions = previousQuestions,
+                                PreviousQuestions = new List<QnADTO> { previousQuestions.Last() },
                                 IsPrompt = true,
                             },
                         },


### PR DESCRIPTION
For multi-level multi-turn QnA KB, storing all previous questions in an AC payload for every prompt will cause the message size is rapidly exceeded MSTeams message size limit. Ideally for storing a context in a multi-turn conversation we should use QnAMakerDialog. 
Quick workaround: Because in the original code all previous questions are never used storing just the last previous question into an AC payload will fix a message size issue and I hope won't cause any breaking changes.

Fix #121
Fix #112