### PR TITLE
Fix default threshold issue

### DIFF
--- a/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/QnaServiceProvider.cs
+++ b/Source/Microsoft.Teams.Apps.FAQPlusPlus.Common/Providers/QnaServiceProvider.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Teams.Apps.FAQPlusPlus.Common.Providers
             {
                 IsTest = isTestKnowledgeBase,
                 Question = question?.Trim(),
-                ScoreThreshold = Convert.ToDouble(this.options.ScoreThreshold, CultureInfo.InvariantCulture),
+                ScoreThreshold = Convert.ToDouble(this.options.ScoreThreshold, CultureInfo.InvariantCulture) * 100,
             };
 
             if (previousQnAId != null && previousUserQuery != null)


### PR DESCRIPTION
According to docs, a threshold should be the default value from arm template x 100. 
https://docs.microsoft.com/en-us/azure/cognitive-services/QnAMaker/Quickstarts/get-answer-from-knowledge-base-using-url-tool?tabs=v1&pivots=url-test-tool-curl

Confirmed by two customers and QnAMaker PG. The threshold should be in the [0-100] range.

Fix #96 