### PR TITLE
[BrokenLinksH2] -- update FAQ target

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,4 +85,4 @@ This project welcomes contributions and suggestions. Most contributions require 
 
 When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
 
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/FAQ/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
**Global effort to fix broken links** 

 @Vishnu-MSFT 

The Content & Learning team is fixing broken links on docs.microsoft.com for the rest of H2. This effort will eliminate potential accessibility, security, and usability issues. This PR includes only link fixes and does not change other content. I’d very much appreciate your timely review and feedback on the link changes I’ve suggested. Thanks!
