### PR TITLE
fix questionAnswerLocation to use subscription location

### DIFF
--- a/Deployment/azuredeploy.json
+++ b/Deployment/azuredeploy.json
@@ -207,7 +207,7 @@
     "configAppUrl": "[concat('https://', variables('configAppName'), '.azurewebsites.net')]",
     "configAppInsightsName": "[concat(parameters('baseResourceName'), '-config')]",
     "questionAnswerAccountName": "[parameters('baseResourceName')]",
-    "questionAnswerLocation": "westus",
+    "questionAnswerLocation": "[parameters('location')]",
     "questionAnswerAppServiceName": "[concat(parameters('baseResourceName'), '-questionAnswer')]",
     "questionAnswerAppInsightsName": "[concat(parameters('baseResourceName'), '-questionAnswer')]",
     "questionAnswerServiceSkuValue": "[parameters('questionAnswerServiceSku')]",


### PR DESCRIPTION
Use the subscription location for the "questionAnswerLocation" instead of hardcoded "westus".  Doing this, the language service is created in the subscription location.
This avoids problems when using the template to deploy to another region. 
